### PR TITLE
Overhaul to execute at form submission (#2)

### DIFF
--- a/caldera-forms-anti-spam.php
+++ b/caldera-forms-anti-spam.php
@@ -3,16 +3,14 @@
 * Plugin Name: Caldera Forms Anti Spam
 * Description: Anti-spam for Caldera Forms. Recaptcha field!
 * Author: Yoohoo Plugins
-* Version: 0.3
+* Version: 0.4
 * Author URI: https://yoohooplugins.com
 * Text Domain: cf-anti-spam
  */
 
-define( 'CF_ANTISPAM_PATH',  plugin_dir_path( __FILE__ ) );
+define( 'CF_ANTISPAM_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CF_ANTISPAM_URL',  plugin_dir_url( __FILE__ ) );
-define( 'CF_ANTISPAM_VER', '0.3' );
-
-
+define( 'CF_ANTISPAM_VER', '0.4' );
 
 add_action( 'caldera_forms_includes_complete', 'cf_antispam_init' );
 
@@ -20,7 +18,6 @@ function cf_antispam_init(){
 	Caldera_Forms_Autoloader::add_root( 'CF_Antispam', __DIR__ . '/classes' );
 	cf_antispam_init_recpatcha();
 }
-
 
 function cf_antispam_init_recpatcha(){
 	$recaptcha = new CF_Antispam_Recapatcha();
@@ -33,5 +30,5 @@ function cf_antispam_init_recpatcha(){
 
 	add_filter( 'caldera_forms_field_attributes-recaptcha', array( $recaptcha, 'field_attrs' ), 10, 2 );
 
-    add_filter( 'caldera_forms_summary_magic_fields', array( $recaptcha, 'remove_from_summary' ), 10, 2 );
+	add_filter( 'caldera_forms_summary_magic_fields', array( $recaptcha, 'remove_from_summary' ), 10, 2 );
 }

--- a/fields/recaptcha/field.php
+++ b/fields/recaptcha/field.php
@@ -1,93 +1,112 @@
-<?php echo $wrapper_before; ?>
-<?php echo empty( $field['config']['recapv'] ) ? $field_label : ''; ?>
-
 <?php
+/**
+ * Renders the field in the visitor-facing form
+ *
+ * @package caldera-forms-anti-spam
+ */
 
-if(false !== strpos($field_input_class, 'has-error')){
+$recaptcha_version = ( ! empty( $field['config']['recapv'] ) && 1 === $field['config']['recapv'] ) ? 'v3' : 'v2';
+
+// phpcs:disable
+echo $wrapper_before;
+// phpcs:enable
+
+if ( 'v2' === $recaptcha_version ) {
+	echo esc_html( $field_label );
+}
+
+if ( false !== strpos( $field_input_class, 'has-error' ) ) {
 	echo '<span class="has-error">';
-	echo 	$field_caption;
+	echo esc_html( $field_caption );
 	echo '</span>';
 }
 
-if( empty( $field['config']['public_key'] ) ){
+if ( empty( $field['config']['public_key'] ) ) {
 	$field['config']['public_key'] = null;
 }
 
 /**
- We have moved the enqueue here as this allows us to alter the URL on the fly
+ * We have moved the enqueue here as this allows us to alter the URL on the fly
 */
 $language = get_locale();
-$script_url = "https://www.google.com/recaptcha/api.js?onload=cf_recaptcha_is_ready&render=explicit&hl=" . $language;
-if (!empty($field['config']['recapv']) && $field['config']['recapv'] === 1 ) {
-	$script_url = "https://www.google.com/recaptcha/api.js?onload=cf_recaptcha_is_ready&render=" . trim($field['config']['public_key']) . "&hl=" . $language;
+if ( 'v3' === $recaptcha_version ) {
+	$script_url = 'https://www.google.com/recaptcha/api.js?render=' . trim( $field['config']['public_key'] ) . '&hl=' . $language;
+} else {
+	$script_url = 'https://www.google.com/recaptcha/api.js?render=explicit&onload=cf_recaptcha_is_ready&hl=' . $language;
 }
-wp_enqueue_script('cf-anti-spam-recapthca-lib', $script_url);
+wp_enqueue_script( 'cf-anti-spam-recapthca-lib', $script_url, array(), 1, true );
 
-?>
+// phpcs:disable
+echo $field_before;
+// phpcs:enable
 
-<?php echo $field_before; ?>
-
-<?php echo Caldera_Forms_Field_Input::html( $field, $field_structure, $form ); ?>
-
-<?php if (!empty($field['config']['recapv']) && $field['config']['recapv'] === 1 ) { ?>
-	<div id="cap<?php echo $field_id; ?>"></div>
-<?php } else { ?>
-	<div id="cap<?php echo $field_id; ?>" class="g-recaptcha" data-sitekey="<?php echo $field['config']['public_key']; ?>" <?php if (!empty($field['config']['invis']) && $field['config']['invis'] === 1 ) { ?>data-size="invisible" <?php } ?>></div>
-<?php } ?>
-
-<?php echo $field_caption; ?>
-
-<?php echo $field_after; ?>
-
-<?php
-	echo $wrapper_after;
-	ob_start();
-?>
-
-	<script>
-
-		var cf_recaptcha_is_ready = function (){
-			jQuery(document).trigger("cf-anti-init-recaptcha");
-		}
-
-		jQuery( function($){
-
-			jQuery(document).on("cf-anti-init-recaptcha", function(){
-				function init_recaptcha_<?php echo $field_id; ?>(){
-
-					var captch = $('#cap<?php echo $field_id; ?>');
-					<?php if (!empty($field['config']['recapv']) && $field['config']['recapv'] === 1 ) { ?>
-						grecaptcha.ready(function() {
-							var captch = $('#cap<?php echo $field_id; ?>');
-					      	grecaptcha.execute("<?php echo trim( $field['config']['public_key'] ); ?>", {action: 'homepage'}).then(function(token) {
-					          $('<input type="hidden" name="cf-recapv-token" value="' + token + '">').insertAfter(captch[0]);
-					      	});
-					  	});
-					<?php } else { ?>
-
-						captch.empty();
-
-
-						grecaptcha.render( captch[0], { "sitekey" : "<?php echo trim( $field['config']['public_key'] ); ?>", "theme" : "<?php echo isset( $field['config']['theme'] ) ? $field['config']['theme'] : "light"; ?>" } );
-
-						// Only load grecaptcha.execute if it's set to invisible mode.
-						<?php if ( !empty( $field['config']['invis']) && $field['config']['invis'] === 1 ) { ?> grecaptcha.execute(); <?php } ?>
-					<?php } ?>
-				}
-
-				jQuery(document).on('click', '.reset_<?php echo $field_id; ?>', function(e){
-					e.preventDefault();
-					init_recaptcha_<?php echo $field_id; ?>();
-				});
-
-				init_recaptcha_<?php echo $field_id; ?>();
-			});
-		});
-
-	</script>
-
+if ( 'v3' === $recaptcha_version ) {
+	echo '<div id="cap' . esc_html( $field_id ) . '"></div>';
+} else {
+	// phpcs:disable
+	echo Caldera_Forms_Field_Input::html( $field, $field_structure, $form );
+	// phpcs:enable
+	?>
+	<div id="cap<?php echo esc_html( $field_id ); ?>" class="g-recaptcha" data-sitekey="<?php echo esc_html( $field['config']['public_key'] ); ?>" 
+		<?php
+		if ( ! empty( $field['config']['invis'] ) && 1 === $field['config']['invis'] ) {
+			echo ' data-size="invisible" ';}
+		?>
+		</div>
 	<?php
+}
 
-		$script_template = ob_get_clean();
+// phpcs:disable
+echo $field_caption;
+echo $field_after;
+echo $wrapper_after;
+// phpcs:enable
 
-		Caldera_Forms_Render_Util::add_inline_data( $script_template, $form );
+ob_start();
+?>
+	<script>
+		var cf_recaptcha_executed = false;
+		var cf_recaptcha_execute = function ( event, obj ) {
+			grecaptcha.ready( function () {
+				var cf_form = jQuery('#cap<?php echo esc_html( $field_id ); ?>').parents('form:first');
+				var cf_form_name = cf_form.attr('aria-label').replace(/[^a-zA-Z]+/g, '_') || 'homepage';
+				grecaptcha.execute("<?php echo esc_html( trim( $field['config']['public_key'] ) ); ?>", {action: cf_form_name}).then( function (token) {
+					var captch = jQuery('#cap<?php echo esc_html( $field_id ); ?>');
+					var captchToken = jQuery('#captoken<?php echo esc_html( $field_id ); ?>');
+					if (captchToken.length === 0) {
+						jQuery('<input type="hidden" id="captoken<?php echo esc_html( $field_id ); ?>" name="cf-recapv-token" value="' + token + '">').insertAfter(captch[0]);
+					} else {
+						captchToken.val(token);
+					}
+					obj.inst.validationResult = true;
+					cf_recaptcha_executed = true;
+					cf_form.submit();
+				});
+			});
+		}
+		var cf_recaptcha_is_ready = function (){
+			<?php if ( 'v2' === $recaptcha_version ) { ?>
+				var captch = jQuery('#cap<?php echo esc_html( $field_id ); ?>');
+				captch.empty();
+
+				grecaptcha.render( captch[0], { "sitekey" : "<?php echo esc_html( trim( $field['config']['public_key'] ) ); ?>", "theme" : "<?php echo esc_html( isset( $field['config']['theme'] ) ? $field['config']['theme'] : 'light' ); ?>" } );
+
+				// Only load grecaptcha.execute if it's set to invisible mode.
+				<?php
+				if ( ! empty( $field['config']['invis'] ) && 1 === $field['config']['invis'] ) {
+					?>
+					grecaptcha.execute(); <?php } ?>
+			<?php } ?>
+		}
+		jQuery(document).on('cf.validate.FormSuccess', function( event, obj ){
+			if ( cf_recaptcha_executed === false ) {
+				///make invalid until we finish the grecaptcha execution
+				obj.inst.validationResult = false;
+				cf_recaptcha_execute( event, obj );
+			}
+		});
+	</script>
+<?php
+$script_template = ob_get_clean();
+Caldera_Forms_Render_Util::add_inline_data( $script_template, $form );
+

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: caldera forms, anti-spam, recaptcha
 Requires at least: 4.5
 Tested up to: 5.4
-Stable tag: 0.2
+Stable tag: 0.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -50,6 +50,14 @@ Once the hidden field is added to your Caldera Form, select the V3 checkbox. (Yo
 
 
 == Changelog ==
+
+= 0.4 =
+* Added form name as action for v3 submissions
+* Changed logic to make it clearer when using v2 or v3
+* Changed script execution to only happen at form submission (prevents timeout bug)
+* Changed script to inject at footer of page
+* Improved code structure to pass WordPress CodeSniffer rules (for field.php)
+* Removed older Caldera code they no longer have in mainline
 
 = 0.3 =
 * Fixed JavaScript syntax issues within the V3 reCAPTCHA handler


### PR DESCRIPTION
Core changes:
* Execution only happens at form submission
* Removed older Caldera code they no longer have in mainline
* Made it clearer when using v2 or v3
* Passing WordPress CodeSniffer rules
* Script now injects at footer of page